### PR TITLE
Add missing namespace statement

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.peakysoftware.plugin_wifi_connect'
     compileSdkVersion 34
 
     compileOptions {


### PR DESCRIPTION
Without this statement there are build errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the Android build configuration with a new parameter to improve package organization and prevent naming conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->